### PR TITLE
[FIX] - Added new listener to storage changes

### DIFF
--- a/assets/scripts/background.js
+++ b/assets/scripts/background.js
@@ -20,9 +20,9 @@ async function createOffscreen() {
 
 chrome.runtime.onStartup.addListener(createOffscreen);
 chrome.runtime.onInstalled.addListener(createOffscreen);
-chrome.runtime.onConnect.addListener(port => {
-  chrome.offscreen.closeDocument()
-  createOffscreen();
+chrome.runtime.onConnect.addListener(async(port) => {
+  await chrome.offscreen.closeDocument()
+  await createOffscreen();
 });
 
 async function check(informations){

--- a/assets/scripts/loadExtension.js
+++ b/assets/scripts/loadExtension.js
@@ -1,6 +1,12 @@
 async function loadWorkedHours(){
-  const informations = await chrome.storage.local.get('tradingworksPlusSharedData');
+  chrome.storage.onChanged.addListener((changes, namespace) => {
+    if (namespace !== 'local') return;
+    if (!changes['tradingworksPlusSharedData']) return;
+    
+    updateContent(changes['tradingworksPlusSharedData'].newValue);
+  });
   
+  const informations = await chrome.storage.local.get('tradingworksPlusSharedData');
   updateContent(informations['tradingworksPlusSharedData']);
 
   setTimeout(loadWorkedHours, 60000);


### PR DESCRIPTION
Auto update aren't not working properly because DOM loads first, so, when the extension popup are called, he loads storage first and fetch new information later, with the listener , he will set new information when the content of the storage changes