### PR TITLE
 Add Select Options for Break Time Increments Up to 1 Hour

### DIFF
--- a/assets/scripts/config.js
+++ b/assets/scripts/config.js
@@ -5,6 +5,7 @@ window.addEventListener('DOMContentLoaded', () => {
   handleButtonSendMessage();
   handleAllowSendMessageToggle();
   handleInputsBot();
+  breakTimeOptions();
 });
 
 function loadFormByData(){
@@ -27,6 +28,26 @@ function loadFormByData(){
     }
   }
 }
+
+function breakTimeOptions(){
+  const breakTimeInput = document.querySelector("#break-time");
+
+  const addOptions = () => {
+    for (let totalMinutes = 0; totalMinutes <= 60; totalMinutes += 5) {
+      const hours = Math.floor(totalMinutes / 60);
+      const minutes = totalMinutes % 60;
+      const hourFormatted = hours.toString().padStart(2, '0');
+      const minuteFormatted = minutes.toString().padStart(2, '0');
+      const time = `${hourFormatted}:${minuteFormatted}`;
+      const option = document.createElement('option');
+      option.value = time;
+      option.textContent = time;
+      breakTimeInput.appendChild(option);
+    }
+  };
+  addOptions();
+}
+
 
 function handleTimeInputs(){
   let hoursInputs = document.querySelectorAll("#work-time, #break-time")

--- a/assets/styles/config.css
+++ b/assets/styles/config.css
@@ -87,7 +87,7 @@ main section.container{
   font-weight: bold;
 }
 
-.container--item input[type="text"], .container--item input[type="password"], .container--item input[type="email"], .container--item input[type="time"]{	
+.container--item input[type="text"], .container--item input[type="password"], .container--item input[type="email"], .container--item input[type="time"], .container--item > select {	
   border: none;
   background-color: var(--atlantis-200);
   padding: .5rem;

--- a/config/index.html
+++ b/config/index.html
@@ -28,7 +28,8 @@
           </div>
           <div class="container--item">
             <label for="break-time">⌛Período de intervalo</label>
-            <input type="text" id="break-time" name="break-time" value="00:00" required>
+            <select id="break-time" name="break-time" required>
+            </select>
             <small>Ex.: 00:15 (15 minutos de intervalo)</small>
           </div>
         </div>


### PR DESCRIPTION
# Description

## Overview
This pull request introduces a significant update to the break time selection feature in tw+. Previously, the break time was inputted as a text field, which was less intuitive and prone to user input errors. With this update, we have transitioned the break time input to a more user-friendly select dropdown, offering predefined options in 5-minute increments, ranging from 5 minutes to a maximum of 1 hour.

## Changes

Replaced the text input field for break time with a select dropdown (#break-time).
Implemented a JavaScript function handleTimeInputs() to dynamically populate the select dropdown with time options, in 5-minute increments, up to 1 hour (00:05 to 01:00).
Adjusted the HTML structure to accommodate the new select element.
Removed the old text input handling logic that was associated with the break time field.