### PR TITLE
fix: displaying incorrect negative hours when we owe less than one hour

### DIFF
--- a/assets/scripts/popupHelper.js
+++ b/assets/scripts/popupHelper.js
@@ -1,8 +1,11 @@
 class PopupHelper {
   static formatBalance(balance) {
-    const balanceHours = String(Math.trunc(balance)).padStart(2, '0');
+    const balanceHours = String(Math.abs(Math.trunc(balance))).padStart(2, '0');
     const balanceMinutes = String(Math.abs(Math.round((balance % 1) * 60))).padStart(2, '0');
-    return `${balanceHours}h${balanceMinutes}m`;
+    let formatString = '';
+    if (balance < 0) formatString = '-';
+    formatString += balanceHours + 'h' + balanceMinutes + 'm';
+    return formatString;
   }
 
   static formatDate(date, format) {


### PR DESCRIPTION
When we view the hours in the time bank and they are negative but we owe less than one hour, the application shows the positive value even though it is negative, see images below, the first is on the website and the second in the application.

1ª
![image](https://github.com/user-attachments/assets/21681380-ae54-491f-9187-bea2412a7f32)

2ª
![image](https://github.com/user-attachments/assets/c599c61a-2ff4-445b-a17e-909571db35ec)

